### PR TITLE
Content Update: Transparent Squid Proxy How-To

### DIFF
--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -79,7 +79,7 @@ can be checked by clicking **Status > Services**.
 
 Also available are:
 
--  **lightsquid** package to view web access reports from the squid log.
--  **SquidGuard** package for who wish to have more fine-grained control
+-  **Lightsquid** package to view web access reports from the squid log.
+-  **squidGuard** package for who wish to have more fine-grained control
    over what web resources may be viewed by clients.
 -  :doc:`Squid Package Tuning </cache-proxy/squid-package-tuning>`

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -11,9 +11,11 @@ Install the Package
 
 First, install the Squid package.
 
-#. Click **System > Packages**
-#. Scroll down until the "squid" package listing is visible
-#. Click |fa-plus| located to the right of the squid package description
+#. Click **System > Package Manager**
+#. Click Available Packages 
+#. Enter "squid" in the search bar and click search or scroll down until the "squid" package listing is visible
+#. Click the install button on the far right
+#. Click Confirm when prompted ("Confirmation Required to install package pfSense-pkg-squid")
 #. Wait for the installer to download, install, and do post-install
    tasks for squid, such as creating the cache directories.
 

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -29,7 +29,7 @@ configured.
 
    #. Hard disk cache size (in MB): Set this as needed, but keep it a reasonable
       size. 3000 (3GB) may be a good place to start.
-   #. Hard disk cache location: Should be */var/squid/cache* but may be
+   #. Hard disk cache location: Should be ``/var/squid/cache`` but may be
       moved if needed
    #. Memory cache size: The amount of RAM that squid should claim for
       caching. Use as much as can be spared, as this is much faster than

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -25,10 +25,10 @@ Configure the Squid Package
 After the installation has finished, the Squid proxy server may be
 configured.
 
-#. Click on **Services > Proxy Server**
-#. Set the options on the **General Settings** tab as desired.
+#. Click on **Services > Squid Proxy Server**
+#. Set the options on the **General** tab as desired.
 
-   #. Proxy Interface: Select which interface the proxy will **listen**
+   #. Proxy Interface(s): Select which interface(s) the proxy will **listen**
       on. *LAN* is probably the desired setting.
    #. Allow users on interface: If this is checked, the subnets for the
       interfaces selected in the last step will automatically have
@@ -47,9 +47,9 @@ configured.
       is operational and tested.
    #. Click Save
 
-#. Click on the **Cache Management** tab.
+#. Click on the **Local Cache** tab.
 
-   #. Hard disk cache size: Set this as needed, but keep it a reasonable
+   #. Hard disk cache size (in MB): Set this as needed, but keep it a reasonable
       size. 3000 (3GB) may be a good place to start.
    #. Hard disk cache location: Should be */var/squid/cache* but may be
       moved if needed
@@ -57,6 +57,8 @@ configured.
       caching. Use as much as can be spared, as this is much faster than
       caching to disk. It should not exceed 50% of the installed RAM,
       however.
+   #. Hard disk cache location: The directory where the cache will be stored.
+      If using a non-default location (for example, if you have added a separate drive for caching), enter it here.
    #. Minimum object size: Can be left at 0 to cache everything, but may
       be raised if small objects are not desired in the cache.
    #. Maximum object size: Objects larger than this setting will not be
@@ -66,7 +68,7 @@ configured.
       This may also be left blank.
    #. Click Save
 
-#. Click on the **Access Control** tab *(optional for most)*
+#. Click on the **ACLs** tab *(optional for most)*
 
    #. If any other subnets will pass through the proxy aside from the
       subnet for the interface squid is using, enter them here.

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -12,10 +12,10 @@ Install the Package
 First, install the Squid package.
 
 #. Click **System > Package Manager**
-#. Click Available Packages 
-#. Enter "squid" in the search bar and click search or scroll down until the "squid" package listing is visible
-#. Click the install button on the far right
-#. Click Confirm when prompted ("Confirmation Required to install package pfSense-pkg-squid")
+#. Click **Available Packages** 
+#. Enter ``squid`` in the search bar and click search or scroll down until the **squid** package listing is visible
+#. Click the **install** button on the far right
+#. Click **Confirm** when prompted ("Confirmation Required to install package pfSense-pkg-squid")
 #. Wait for the installer to download, install, and do post-install
    tasks for squid, such as creating the cache directories.
 
@@ -24,6 +24,27 @@ Configure the Squid Package
 
 After the installation has finished, the Squid proxy server may be
 configured.
+
+#. Click on the **Local Cache** tab.
+
+   #. Hard disk cache size (in MB): Set this as needed, but keep it a reasonable
+      size. 3000 (3GB) may be a good place to start.
+   #. Hard disk cache location: Should be */var/squid/cache* but may be
+      moved if needed
+   #. Memory cache size: The amount of RAM that squid should claim for
+      caching. Use as much as can be spared, as this is much faster than
+      caching to disk. It should not exceed 50% of the installed RAM,
+      however.
+   #. Hard disk cache location: The directory where the cache will be stored.
+      If using a non-default location enter it here. 
+   #. Minimum object size: Can be left at 0 to cache everything, but may
+      be raised if small objects are not desired in the cache.
+   #. Maximum object size: Objects larger than this setting will not be
+      saved on disk. If speed is more desirable than saving bandwidth,
+      this should be set to a low value.
+   #. Do Not Cache: Set a list of domains that should never be cached.
+      This may also be left blank.
+   #. Click Save
 
 #. Click on **Services > Squid Proxy Server**
 #. Set the options on the **General** tab as desired.
@@ -47,27 +68,6 @@ configured.
       is operational and tested.
    #. Click Save
 
-#. Click on the **Local Cache** tab.
-
-   #. Hard disk cache size (in MB): Set this as needed, but keep it a reasonable
-      size. 3000 (3GB) may be a good place to start.
-   #. Hard disk cache location: Should be */var/squid/cache* but may be
-      moved if needed
-   #. Memory cache size: The amount of RAM that squid should claim for
-      caching. Use as much as can be spared, as this is much faster than
-      caching to disk. It should not exceed 50% of the installed RAM,
-      however.
-   #. Hard disk cache location: The directory where the cache will be stored.
-      If using a non-default location (for example, if you have added a separate drive for caching), enter it here.
-   #. Minimum object size: Can be left at 0 to cache everything, but may
-      be raised if small objects are not desired in the cache.
-   #. Maximum object size: Objects larger than this setting will not be
-      saved on disk. If speed is more desirable than saving bandwidth,
-      this should be set to a low value.
-   #. Do Not Cache: Set a list of domains that should never be cached.
-      This may also be left blank.
-   #. Click Save
-
 #. Click on the **ACLs** tab *(optional for most)*
 
    #. If any other subnets will pass through the proxy aside from the
@@ -79,7 +79,7 @@ can be checked by clicking **Status > Services**.
 
 Also available are:
 
--  lightsquid package to view web access reports from the squid log.
--  SquidGuard package for who wish to have more fine-grained control
+-  **lightsquid** package to view web access reports from the squid log.
+-  **SquidGuard** package for who wish to have more fine-grained control
    over what web resources may be viewed by clients.
 -  :doc:`Squid Package Tuning </cache-proxy/squid-package-tuning>`

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -59,7 +59,7 @@ configured.
       redirect outbound HTTP (tcp/80) traffic through the proxy.
    #. Enabled logging: Check this if logging is needed, be sure to put a
       path in the following box
-   #. Log Store Directory: Should be */var/squid/log* unless another
+   #. Log Store Directory: Should be ``/var/squid/log`` unless another
       location is absolutely necessary.
    #. Proxy Port: **Leave this as 3128**. There is no need to change the
       port number for the transparent proxy to work.

--- a/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
+++ b/source/cache-proxy/setup-squid-as-a-transparent-proxy.rst
@@ -44,7 +44,7 @@ configured.
       this should be set to a low value.
    #. Do Not Cache: Set a list of domains that should never be cached.
       This may also be left blank.
-   #. Click Save
+   #. Click **Save**.
 
 #. Click on **Services > Squid Proxy Server**
 #. Set the options on the **General** tab as desired.
@@ -66,13 +66,13 @@ configured.
    #. The remaining settings may be left at their defaults, or changed
       if desired. It is likely best to leave them alone until the proxy
       is operational and tested.
-   #. Click Save
+   #. Click **Save**.
 
 #. Click on the **ACLs** tab *(optional for most)*
 
    #. If any other subnets will pass through the proxy aside from the
       subnet for the interface squid is using, enter them here.
-   #. Click Save
+   #. Click **Save**.
 
 That's it! Squid should be up and running. The status of the squid proxy
 can be checked by clicking **Status > Services**.


### PR DESCRIPTION
Hi all,

I was following the docs on [Configuring the Squid Package as a Transparent HTTP Proxy](https://www.netgate.com/docs/pfsense/cache-proxy/setup-squid-as-a-transparent-proxy.html) and found a few very minor discrepancies with the current versions of pfSense (2.4.3) and squid (0.4.43_1). 

I believe I have corrected these minor differences here, mainly focusing on tab names and the package install process. 

How should we handle graphics like `|fa-plus|`? I did not see any mention of these in the style guide.
Should we include a section for syncing squid settings? I was pleasantly surprised to see how simple it was to just configure the XMLRPC Sync to "Sync to configured system backup server" as it... just worked. 

Thanks!
