### PR TITLE
Update VirtIO Driver Support page with known issue

### DIFF
--- a/source/virtualization/virtio-driver-support.rst
+++ b/source/virtualization/virtio-driver-support.rst
@@ -18,7 +18,7 @@ reach systems (at least other VM guests, possibly others) protected by pfSense
 
 The issue is most likely caused by `FreeBSD Bug 165059`_.
 
-Also, there is a known issue with BGP MD5 sessions and TCP-MD5 when Hardware Checksum Offloading (rxcsum) is disabled. See `Bug #8407` and `Bug #7969`. With the inclusion of FreeBSD 11.2-RELEASE in pfSense 2.4.4 this issue is corrected. See `FreeBSD Bugzilla – Bug 223835`.
+Also, there is a known issue with BGP MD5 sessions and TCP-MD5 when Hardware Checksum Offloading (rxcsum) is disabled. See `Bug #8407`_ and `Bug #7969`_. With the inclusion of FreeBSD 11.2-RELEASE in pfSense 2.4.4 this issue is corrected. See `FreeBSD Bugzilla – Bug 223835`_.
 
 Hardware checksums and other NIC offloading features like TSO may also need to
 be disabled on the hypervisor system in addition to the pfSense VM.

--- a/source/virtualization/virtio-driver-support.rst
+++ b/source/virtualization/virtio-driver-support.rst
@@ -25,5 +25,5 @@ be disabled on the hypervisor system in addition to the pfSense VM.
 
 .. _FreeBSD Bug 165059: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=165059
 .. _FreeBSD Bugzilla – Bug 223835: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223835
-.. _Bug #8407:https://redmine.pfsense.org/issues/8407
-.. _Bug #7969:https://redmine.pfsense.org/issues/7969
+.. _Bug #8407: https://redmine.pfsense.org/issues/8407
+.. _Bug #7969: https://redmine.pfsense.org/issues/7969

--- a/source/virtualization/virtio-driver-support.rst
+++ b/source/virtualization/virtio-driver-support.rst
@@ -18,7 +18,12 @@ reach systems (at least other VM guests, possibly others) protected by pfSense
 
 The issue is most likely caused by `FreeBSD Bug 165059`_.
 
+Also, there is a known issue with BGP MD5 sessions and TCP-MD5 when Hardware Checksum Offloading (rxcsum) is disabled. See `Bug #8407` and `Bug #7969`. With the inclusion of FreeBSD 11.2-RELEASE in pfSense 2.4.4 this issue is corrected. See `FreeBSD Bugzilla – Bug 223835`.
+
 Hardware checksums and other NIC offloading features like TSO may also need to
 be disabled on the hypervisor system in addition to the pfSense VM.
 
 .. _FreeBSD Bug 165059: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=165059
+.. _FreeBSD Bugzilla – Bug 223835: https://bugs.freebsd.org/bugzilla/show_bug.cgi?id=223835
+.. _Bug #8407:https://redmine.pfsense.org/issues/8407
+.. _Bug #7969:https://redmine.pfsense.org/issues/7969


### PR DESCRIPTION
There is a known issue with BGP MD5 / TCP-MD5 when Hardware Checksum Offloading is disabled that is not immediately evident. People following this suggestion in virtualized environments who rely on TCP-MD5 may find this note helpful.