### PR TITLE
Added info on where to locate device key

### DIFF
--- a/source/backup/autoconfigbackup.rst
+++ b/source/backup/autoconfigbackup.rst
@@ -67,6 +67,9 @@ To identify a specific firewall, an unique identifier is required to save or
 restore a backup configuration. ACB uses an SHA256 hash of the SSH public key on
 the firewall for this purpose.
 
+The device key is located on the **Services > Auto Config Backup** menu item, 
+under the **Restore** and **Backup now** tabs.
+
 .. warning:: **Keep a careful record of this Device Key**!
 
    If the **Device Key** of a firewall is lost, there is a chance it can be


### PR DESCRIPTION
I couldn't find the device key location in any of the documentation and ended up manually copying the ssh public keys from the firewall before ever visiting the tabs where it's listed.  I'd like to help others avoid that extra work.