### PR TITLE
Updated section about ftp validation

### DIFF
--- a/source/certificates/acme-validation.rst
+++ b/source/certificates/acme-validation.rst
@@ -124,10 +124,34 @@ To use this method:
     ``/.well-known/acme-challenge`` at the end
 
     .. warning:: Make sure the specified user has write permissions to the
-       directory!
+       directory! 
+       Also see note below.
+       
+  :Note:
+    The simplest way to achive that the specified user has write permissions to the directory whitout the security concerns
+    is to create a user in the server that can act on behaf of all the sites. All the **full path** fields should be set to this users directory
+
+    #. In this config you wolud have a user on the server, lets say **acme**. 
+    #. In the home directory of the designated user create the folder structure **~/.well-known/acme-challenge**
+    #. In webserver configuration create an alias for the path **/.well-known/acme-challenge** for all sites.
+      * In Apache2 it would be somthing like this::
+        
+          #Acme config for apache (/etc/acpache2/conf-avalable/acme.conf)
+          #Add to conf-available
+          #Enable with a2enconf
+
+          Alias /.well-known/acme-challenge /home/acme/.well-known/acme-challenge
+          <Directory /home/acme/.well-known/acme-challenge>
+              AllowOverride None
+              Require all granted
+          </Directory>
 
 * Click **Save**
 * Click **Issue/Renew**
+
+
+  
+
 
 .. _acme-validation-localfolder:
 


### PR DESCRIPTION
Hi. 
-FTP validation-

I added a note about a configuration strategy that works very good for me. In this case i don't have to do any extra configuration when i add extra SAN entries.

I added this mostly because i think there might be something fishy with the acme-plugin in pfsense. Before, the the site I registered did not need to pass the test for if the challenge was reachable from the web (I don't know if this was the right or wrong behavior) but now it must (or at least it needed for me). To keep my administration to a minimum when adding/removing sites and managing access permissions i though this approach was simple. Since the documentation does not explicitly tell if the site needs to be reachable for this validation method i thought it best to provide it non the less.

Sorry about the formatting but it is my first attempt at ReStructuredText.
Hope you find it useful (and that i managed to conform to the style-guide).