### PR TITLE
Minor gramatical fix.

### DIFF
--- a/source/backup/autoconfigbackup.rst
+++ b/source/backup/autoconfigbackup.rst
@@ -44,7 +44,7 @@ Encryption Password
 -------------------
 
 Before the configuration is transmitted to Netgate servers, the firewall
-encrypts the backup using the AES-256-CBC algorithm and a password that created
+encrypts the backup using the AES-256-CBC algorithm and a password that is created
 by the firewall administrator. This password never leaves the firewall and is
 never shared.
 


### PR DESCRIPTION
Added the word 'is' to the following sentence:
"... a password that is created by the firewall administrator."