### PR TITLE
Add a note about advskew

### DIFF
--- a/source/highavailability/dhcp-failover-troubleshooting.rst
+++ b/source/highavailability/dhcp-failover-troubleshooting.rst
@@ -15,6 +15,8 @@ Troubleshooting DHCP Failover
    and secondary nodes match.
 #. Stop and restart the DHCP daemon from **Status > Services** on both
    nodes and check the status after a few moments
+#. Check the nodes VIP status. The master node should have a value below
+   20 for advskew, the slave should have an advskew value above 20. 
 #. Both nodes must be running the same version of pfSense. Update both
    nodes to the newest available release if they do not match. Older
    versions may have problems with various aspects of DHCP failover that


### PR DESCRIPTION
The advskew interferes with the DHCP HA mode, when this setting is not properly configured, DHCP will stay in recover mode with a state-unknown message. 
Found the fix here: https://forum.netgate.com/topic/79489/dhcp-stuck-in-recover/5 