### PR TITLE
Update certificate-management.rst

### DIFF
--- a/source/certificates/certificate-management.rst
+++ b/source/certificates/certificate-management.rst
@@ -34,12 +34,12 @@ Certificate Authority*, fill out the required information and click
 Certificates
 ------------
 
-**Certificates** are manage on the **Certificates** tab.
+**Certificates** are managed on the **Certificates** tab.
 
 The certificates and keys may also be downloaded from this list view:
 
-:|fa-certificate|: Exports the certificate file
-:|fa-key|: Export the private key for this certificate
+:|fa-certificate|: Exports the certificate file.
+:|fa-key|: Exports the private key for this certificate.
 :|fa-archive|: Generates a PKCS#12 ``.p12`` file with the CA certificate, user
   certificate, and user key contained inside.
 


### PR DESCRIPTION
More typos. s/manage/managed/. And some consistency punctuation. Some sentences are "icon" + sentence w/period in some places and just "icon" + sentence (no period) in others. (Yeah, I'm anal in coding as well as prose consistency, I guess. Makes things more readable in both scenarios.) And verb tense agreement. (Exports, export, generates -> exports, exports, generates.)

I think I'm done picking on this page. :-) (Was reading for info and noticed these ticky-tack updates.)