### PR TITLE
Explain that floating rules with no interfaces = all interfaces

### DIFF
--- a/source/firewall/floating-rules.rst
+++ b/source/firewall/floating-rules.rst
@@ -18,7 +18,7 @@ Floating Rules can:
 -  Filter traffic from the firewall itself
 -  Filter traffic in the outbound direction (all other tabs are Inbound
    processing only)
--  Apply rules to multiple interfaces
+-  Apply rules to multiple interfaces (if no interfaces are selected then the rule effectively applies to all interfaces)
 -  Apply filtering in a "last match wins" way rather than "first match
    wins" (**quick**)
 -  Apply traffic shaping to match traffic but not affect it's pass/block


### PR DESCRIPTION
There was a question in the forum about this https://forum.netgate.com/topic/146996/firewall-floating-rules-selecting-interfaces

Should we put an explanation like this, or does it need to have whole paragraphs explaining the detail of floating rule options?