### PR TITLE
Ignore files generated by Eclipse and PHPstorm IDEs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,9 @@ draft.sh
 _themes/
 build/
 venv
+# eclipse
+.buildpath
+.project
+.settings/
+# PhpStorm
+.idea


### PR DESCRIPTION
so that people using these IDEs are less likely to accidentally commit the files generated by their IDE.