### PR TITLE
Reverted part of 52f0a93, return IPSec PFS suggestion to off

### DIFF
--- a/source/vpn/ipsec/configuring-an-ipsec-remote-access-mobile-vpn-using-ikev2-with-eap-mschapv2.rst
+++ b/source/vpn/ipsec/configuring-an-ipsec-remote-access-mobile-vpn-using-ikev2-with-eap-mschapv2.rst
@@ -125,7 +125,7 @@ Phase 2
 *  Set **Protocol** to *ESP*
 *  Set **Encryption Algorithms** to *AES Auto*.
 *  Set **Hash Algorithms** to *SHA256*
-*  Set **PFS key group** to *14 (2048 bit)*
+*  Set **PFS key group** to *off*
 *  Set **Lifetime** to *3600*
 *  Click **Save**
 


### PR DESCRIPTION
This returns the IPSec phase 2 PFS setting suggestion back to 'off', as it was before my change in 52f0a93.  Did this because unfortunately macOS doesn't actually like that setting, at least not without an MDM config, which is a bit complicated for people doing first time setup with this guide.