### PR TITLE
Update flow_control disable flag for ix

### DIFF
--- a/source/hardware/tuning-and-troubleshooting-network-cards.rst
+++ b/source/hardware/tuning-and-troubleshooting-network-cards.rst
@@ -272,7 +272,7 @@ ixgbe(4) (aka ix):
 
 * Either this (pfSense 2.3+)::
 
-    dev.ix.0.fc=0
+    hw.ix.flow_control=0
 
 * Or this (pfSense 2.2.x and before)::
 


### PR DESCRIPTION
dev.ix.0.fc value is overridden by hw.ix.flow_control during boot.